### PR TITLE
ReRunModesAndOverlaysOnRefresh

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -592,8 +592,12 @@
     var comp = compensateForHScroll(display) - display.scroller.scrollLeft + cm.doc.scrollLeft;
     var gutterW = display.gutters.offsetWidth, left = comp + "px";
     for (var i = 0; i < view.length; i++) if (!view[i].hidden) {
-      if (cm.options.fixedGutter && view[i].gutter)
-        view[i].gutter.style.left = left;
+      if (cm.options.fixedGutter) {
+        if (view[i].gutter)
+          view[i].gutter.style.left = left;
+        if (view[i].gutterBackground)
+          view[i].gutterBackground.style.left = left;
+      }
       var align = view[i].alignable;
       if (align) for (var j = 0; j < align.length; j++)
         align[j].style.left = left;
@@ -1575,7 +1579,6 @@
       var input = this, cm = input.cm;
       var div = input.div = display.lineDiv;
       disableBrowserMagic(div);
-      if (cm.options.spellcheck) div.setAttribute("spellcheck", cm.options.spellcheck);
 
       on(div, "paste", function(e) {
         if (!signalDOMEvent(cm, e)) handlePaste(e, cm);
@@ -2689,6 +2692,16 @@
     return {node: node, start: start, end: end, collapse: collapse, coverStart: mStart, coverEnd: mEnd};
   }
 
+  function getUsefulRect(rects, bias) {
+    var rect = nullRect
+    if (bias == "left") for (var i = 0; i < rects.length; i++) {
+      if ((rect = rects[i]).left != rect.right) break
+    } else for (var i = rects.length - 1; i >= 0; i--) {
+      if ((rect = rects[i]).left != rect.right) break
+    }
+    return rect
+  }
+
   function measureCharInner(cm, prepared, ch, bias) {
     var place = nodeAndOffsetInLineMap(prepared.map, ch, bias);
     var node = place.node, start = place.start, end = place.end, collapse = place.collapse;
@@ -2698,17 +2711,10 @@
       for (var i = 0; i < 4; i++) { // Retry a maximum of 4 times when nonsense rectangles are returned
         while (start && isExtendingChar(prepared.line.text.charAt(place.coverStart + start))) --start;
         while (place.coverStart + end < place.coverEnd && isExtendingChar(prepared.line.text.charAt(place.coverStart + end))) ++end;
-        if (ie && ie_version < 9 && start == 0 && end == place.coverEnd - place.coverStart) {
+        if (ie && ie_version < 9 && start == 0 && end == place.coverEnd - place.coverStart)
           rect = node.parentNode.getBoundingClientRect();
-        } else if (ie && cm.options.lineWrapping) {
-          var rects = range(node, start, end).getClientRects();
-          if (rects.length)
-            rect = rects[bias == "right" ? rects.length - 1 : 0];
-          else
-            rect = nullRect;
-        } else {
-          rect = range(node, start, end).getBoundingClientRect() || nullRect;
-        }
+        else
+          rect = getUsefulRect(range(node, start, end).getClientRects(), bias)
         if (rect.left || rect.right || start == 0) break;
         end = start;
         start = start - 1;
@@ -5330,6 +5336,7 @@
 
     refresh: methodOp(function() {
       var oldHeight = this.display.cachedTextHeight;
+      this.state.modeGen++;
       regChange(this);
       this.curOp.forceUpdate = true;
       clearCaches(this);
@@ -8559,8 +8566,9 @@
     if (badBidiRects != null) return badBidiRects;
     var txt = removeChildrenAndAdd(measure, document.createTextNode("A\u062eA"));
     var r0 = range(txt, 0, 1).getBoundingClientRect();
-    if (!r0 || r0.left == r0.right) return false; // Safari returns null in some cases (#2780)
     var r1 = range(txt, 1, 2).getBoundingClientRect();
+    removeChildren(measure);
+    if (!r0 || r0.left == r0.right) return false; // Safari returns null in some cases (#2780)
     return badBidiRects = (r1.right - r0.right < 3);
   }
 
@@ -8926,7 +8934,7 @@
 
   // THE END
 
-  CodeMirror.version = "5.16.2";
+  CodeMirror.version = "5.17.1";
 
   return CodeMirror;
 });


### PR DESCRIPTION
Re-runs modes and overlays on refresh()

This allows refresh() to update the text with any updates done to the modes or overlays.

Case in point, a spellchecker overlay 'igonore all' options add a word to a dictionary of words that will not be counted as typos even if they are not in the dictionaries. Calling refresh() with this fix will then ignore those typos on any line.

This is needed whenever there is a need to re run a mode or an overlay on all lines
